### PR TITLE
288 theme kit cannot install and cannot sync on mac os

### DIFF
--- a/ntk/command.py
+++ b/ntk/command.py
@@ -39,7 +39,6 @@ class Command:
 
         return template_names
 
-
     def _handle_files_change(self, changes):
         for event_type, pathfile in changes:
             template_name = get_template_name(pathfile)

--- a/ntk/command.py
+++ b/ntk/command.py
@@ -25,6 +25,21 @@ class Command:
         self.config = Config()
         self.gateway = Gateway(store=self.config.store, apikey=self.config.apikey)
 
+    def _get_accept_files(self, template_names):
+        files = []
+        glob_list = map(lambda x: os.path.abspath(x), GLOB_PATTERN)
+        for pattern in glob_list:
+            files.extend(glob.glob(pattern))
+
+        if template_names:
+            filenames = list(map(lambda x: os.path.abspath(x), template_names))
+            template_names = list(filter(lambda x: x in files, filenames))
+        else:
+            template_names = files
+
+        return template_names
+
+
     def _handle_files_change(self, changes):
         for event_type, pathfile in changes:
             template_name = get_template_name(pathfile)
@@ -36,7 +51,7 @@ class Command:
                 self._delete_templates([template_name])
 
     def _push_templates(self, template_names):
-        template_names = self.get_accept_files(template_names)
+        template_names = self._get_accept_files(template_names)
         template_count = len(template_names)
 
         logging.info(f'[{self.config.env}] Connecting to {self.config.store}')
@@ -160,17 +175,3 @@ class Command:
 
         loop = asyncio.get_event_loop()
         loop.run_until_complete(main())
-
-    def get_accept_files(self, template_names):
-        files = []
-        glob_list = map(lambda x: os.path.abspath(x), GLOB_PATTERN)
-        for pattern in glob_list:
-            files.extend(glob.glob(pattern))
-
-        if template_names:
-            filenames = list(map(lambda x: os.path.abspath(x), template_names))
-            template_names = list(filter(lambda x: x in files, filenames))
-        else:
-            template_names = files
-
-        return template_names

--- a/ntk/command.py
+++ b/ntk/command.py
@@ -107,7 +107,7 @@ class Command:
                 template_names, prefix=f'[{self.config.env}] Progress:', suffix='Complete', length=50):
             template_name = get_template_name(template_name)
             self.gateway.delete_template(theme_id=self.config.theme_id, template_name=template_name)
-            
+
     @parser_config(theme_id_required=False)
     def init(self, parser):
         if parser.name:
@@ -163,13 +163,13 @@ class Command:
 
     def get_accept_files(self, template_names):
         files = []
-        glob_list = map(lambda x : os.path.abspath(x), GLOB_PATTERN)
+        glob_list = map(lambda x: os.path.abspath(x), GLOB_PATTERN)
         for pattern in glob_list:
             files.extend(glob.glob(pattern))
 
         if template_names:
-            filenames = list(map(lambda x : os.path.abspath(x), template_names))
-            template_names = list(filter(lambda x : x in files, filenames))
+            filenames = list(map(lambda x: os.path.abspath(x), template_names))
+            template_names = list(filter(lambda x: x in files, filenames))
         else:
             template_names = files
 

--- a/ntk/command.py
+++ b/ntk/command.py
@@ -92,7 +92,7 @@ class Command:
         current_files = []
         for template in progress_bar(templates, prefix=f'[{self.config.env}] Progress:', suffix='Complete', length=50):
             template_name = str(template['name'])
-            current_pathfile = os.path.join(os.getcwd(), template_name)
+            current_pathfile = os.path.abspath(template_name)
             current_files.append(current_pathfile.replace('\\', '/'))
 
             # create directories
@@ -162,7 +162,8 @@ class Command:
 
     @parser_config()
     def watch(self, parser):
-        current_pathfile = os.path.join(os.getcwd())
+        current_pathfile = os.path.abspath(".")
+
         logging.info(f'[{self.config.env}] Current store {self.config.store}')
         logging.info(f'[{self.config.env}] Current theme id {self.config.theme_id}')
         logging.info(f'[{self.config.env}] Preview theme URL {self.config.store}?preview_theme={self.config.theme_id}')

--- a/ntk/conf.py
+++ b/ntk/conf.py
@@ -8,6 +8,34 @@ CONFIG_FILE = os.path.join(os.getcwd(), CONFIG_FILE_NAME)
 
 CONTENT_FILE_EXTENSIONS = ['.html', '.json', '.css', '.js']
 MEDIA_FILE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.woff', '.woff2', '.ico']
+GLOB_PATTERN = [
+    "assets/*.woff2",
+    "assets/*.gif",
+    "assets/*.ico",
+    "assets/*.html",
+    "assets/*.json",
+    "assets/*.png",
+    "assets/*.jpg",
+    "assets/*.jpeg",
+    "assets/*.svg",
+    "assets/*.css",
+    "assets/*.scss",
+    "assets/*.eot",
+    "assets/*.tff",
+    "assets/*.woff",
+    "assets/*.js",
+    "assets/*.webp",
+    "assets/*.mp4",
+    "assets/*.webm",
+    "assets/*.mp3",
+    "assets/*.pdf",
+    "checkout/*.html",
+    "config/*.json",
+    "layout/*.html",
+    "partials/*.html",
+    "templates/*.html",
+    "locales/*.json",
+]
 
 
 class Config(object):

--- a/ntk/conf.py
+++ b/ntk/conf.py
@@ -3,8 +3,8 @@ import logging
 import os
 import yaml
 
-CONFIG_FILE_NAME = 'config.yml'
-CONFIG_FILE = os.path.join(os.getcwd(), CONFIG_FILE_NAME)
+CONFIG_FILE_NAME = './config.yml'
+CONFIG_FILE = os.path.abspath(CONFIG_FILE_NAME)
 
 CONTENT_FILE_EXTENSIONS = ['.html', '.json', '.css', '.js']
 MEDIA_FILE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.woff', '.woff2', '.ico']

--- a/ntk/decorator.py
+++ b/ntk/decorator.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-from requests.exceptions import HTTPError
 
 logging.basicConfig(
     format='%(asctime)s %(levelname)s %(message)s',
@@ -50,8 +49,12 @@ def check_error(error_format='{error_default} -> {error_msg}', response_json=Tru
                         error_msg += f'"{key}" : {" ".join(value)}'
                     else:
                         error_msg += value
-            raise HTTPError(error_format.format(
-                **vars(self), **func_kwargs, error_default=error_default, error_msg=error_msg))
+
+            error_log = error_format.format(**vars(self), **func_kwargs, error_default=error_default, error_msg=error_msg)
+
+            logging.info(f'{error_log}')
+
+            return response
 
         return _wrapper
 

--- a/ntk/decorator.py
+++ b/ntk/decorator.py
@@ -50,7 +50,9 @@ def check_error(error_format='{error_default} -> {error_msg}', response_json=Tru
                     else:
                         error_msg += value
 
-            error_log = error_format.format(**vars(self), **func_kwargs, error_default=error_default, error_msg=error_msg)
+            error_log = error_format.format(
+                **vars(self), **func_kwargs, error_default=error_default, error_msg=error_msg
+            )
 
             logging.info(f'{error_log}')
 

--- a/ntk/gateway.py
+++ b/ntk/gateway.py
@@ -1,5 +1,4 @@
 import requests
-from requests.models import HTTPError
 
 from ntk.decorator import check_error
 

--- a/ntk/gateway.py
+++ b/ntk/gateway.py
@@ -50,7 +50,6 @@ class Gateway:
             name=template_name,
             content=content
         )
-        print('payload', payload)
 
         return self._request("POST", url, apikey=self.apikey, payload=payload, files=files)
 

--- a/ntk/gateway.py
+++ b/ntk/gateway.py
@@ -1,4 +1,5 @@
 import requests
+from requests.models import HTTPError
 
 from ntk.decorator import check_error
 
@@ -49,6 +50,7 @@ class Gateway:
             name=template_name,
             content=content
         )
+        print('payload', payload)
 
         return self._request("POST", url, apikey=self.apikey, payload=payload, files=files)
 

--- a/ntk/utils.py
+++ b/ntk/utils.py
@@ -6,7 +6,7 @@ def get_template_name(pathfile):
     # change linux path ./partials/alert_messages.html -> partials/alert_messages.html
     # change window path .\partials\alert_messages.html -> partials/alert_messages.html
     pathfile = pathfile.replace('\\', '/').replace('./', '')
-    return os.path.relpath(os.path.join(os.getcwd(), pathfile))
+    return os.path.relpath(pathfile)
 
 
 def progress_bar(iterable, prefix='', suffix='', decimals=1, length=100, fill='█', printEnd="\r"):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 
 tests_require = [
     "flake8==3.9.2",

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -13,6 +13,7 @@ class TestCommand(unittest.TestCase):
     @patch('ntk.command.Gateway', autospec=True)
     def setUp(self, mock_gateway, mock_load_yaml, mock_patch_exists):
         mock_patch_exists.return_value = True
+        
         mock_load_yaml.return_value = {
             'sandbox': {
                 'apikey': 'abc123f0122395acd',
@@ -305,7 +306,12 @@ class TestCommand(unittest.TestCase):
     #####
     # watch (_handle_files_change)
     #####
-    def test_watch_command_should_call_gateway_with_correct_arguments_belong_to_files_change(self):
+    @patch("ntk.command.Command.get_accept_file", autospec=True)
+    def test_watch_command_should_call_gateway_with_correct_arguments_belong_to_files_change(self, mock_get_accept_file):
+        mock_get_accept_file.return_value = [
+            'assets/base.html',
+        ]
+
         self.mock_gateway.return_value.create_or_update_template.return_value.ok = True
         self.mock_gateway.return_value.create_or_update_template.return_value.headers = {
             'content-type': 'application/json'}
@@ -323,6 +329,7 @@ class TestCommand(unittest.TestCase):
             self.command._handle_files_change(changes)
             content = '{% load i18n %}\n\n<div class="mt-2">My home page</div>'
 
+            print('self.mock_gateway.mock_calls)', self.mock_gateway.mock_calls)
             # Change.added
             expected_call_added = call().create_or_update_template(
                 theme_id=1234, template_name='assets/base.html', content=content, files={})

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -13,7 +13,7 @@ class TestCommand(unittest.TestCase):
     @patch('ntk.command.Gateway', autospec=True)
     def setUp(self, mock_gateway, mock_load_yaml, mock_patch_exists):
         mock_patch_exists.return_value = True
-        
+
         mock_load_yaml.return_value = {
             'sandbox': {
                 'apikey': 'abc123f0122395acd',
@@ -307,7 +307,9 @@ class TestCommand(unittest.TestCase):
     # watch (_handle_files_change)
     #####
     @patch("ntk.command.Command.get_accept_files", autospec=True)
-    def test_watch_command_should_call_gateway_with_correct_arguments_belong_to_files_change(self, mock_get_accept_file):
+    def test_watch_command_should_call_gateway_with_correct_arguments_belong_to_files_change(
+        self, mock_get_accept_file
+    ):
         mock_get_accept_file.return_value = [
             f'{os.getcwd()}/assets/base.html',
             f'{os.getcwd()}/layout/base.html'

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -202,12 +202,12 @@ class TestCommand(unittest.TestCase):
         self.assertEqual(self.mock_gateway.mock_calls, expected_gateway_calls)
 
         # create assets/image.png
-        self.assertIn(call(os.path.join(os.getcwd(), 'assets/image.png'), 'wb'), mock_open_file.mock_calls)
+        self.assertIn(call(os.path.abspath('assets/image.png'), 'wb'), mock_open_file.mock_calls)
         self.assertIn(call().__enter__().write(b'\xc2\x89'), mock_open_file.mock_calls)
 
         # create layout/base.html
         self.assertIn(
-            call(os.path.join(os.getcwd(), 'layout/base.html'), 'w', encoding='utf-8'), mock_open_file.mock_calls)
+            call(os.path.abspath('layout/base.html'), 'w', encoding='utf-8'), mock_open_file.mock_calls)
         self.assertIn(call().__enter__().write(
             '{% load i18n %}\n\n<div class="mt-2">My home page</div>'), mock_open_file.mock_calls)
 
@@ -260,12 +260,12 @@ class TestCommand(unittest.TestCase):
         self.assertEqual(self.mock_gateway.mock_calls, expected_gateway_calls)
 
         # create assets/image.png
-        self.assertIn(call(os.path.join(os.getcwd(), 'assets/image.png'), 'wb'), mock_open_file.mock_calls)
+        self.assertIn(call(os.path.abspath('assets/image.png'), 'wb'), mock_open_file.mock_calls)
         self.assertIn(call().__enter__().write(b'\xc2\x89'), mock_open_file.mock_calls)
 
         # create layout/base.html
         self.assertIn(
-            call(os.path.join(os.getcwd(), 'layout/base.html'), 'w', encoding='utf-8'), mock_open_file.mock_calls)
+            call(os.path.abspath('layout/base.html'), 'w', encoding='utf-8'), mock_open_file.mock_calls)
         self.assertIn(call().__enter__().write(
             '{% load i18n %}\n\n<div class="mt-2">My home page</div>'), mock_open_file.mock_calls)
         mock_write_config.assert_not_called()
@@ -298,7 +298,7 @@ class TestCommand(unittest.TestCase):
         self.assertEqual(self.mock_gateway.mock_calls, expected_gateway_calls)
 
         # create assets/image.png
-        self.assertIn(call(os.path.join(os.getcwd(), 'assets/image.png'), 'wb'), mock_open_file.mock_calls)
+        self.assertIn(call(os.path.abspath('assets/image.png'), 'wb'), mock_open_file.mock_calls)
         self.assertIn(call().__enter__().write(b'\xc2\x89'), mock_open_file.mock_calls)
 
         mock_write_config.assert_not_called()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -306,7 +306,7 @@ class TestCommand(unittest.TestCase):
     #####
     # watch (_handle_files_change)
     #####
-    @patch("ntk.command.Command.get_accept_files", autospec=True)
+    @patch("ntk.command.Command._get_accept_files", autospec=True)
     def test_watch_command_should_call_gateway_with_correct_arguments_belong_to_files_change(
         self, mock_get_accept_file
     ):
@@ -341,7 +341,7 @@ class TestCommand(unittest.TestCase):
                 theme_id=1234, template_name='layout/base.html')
             self.assertIn(expected_call_deleted, self.mock_gateway.mock_calls)
 
-    @patch("ntk.command.Command.get_accept_files", autospec=True)
+    @patch("ntk.command.Command._get_accept_files", autospec=True)
     @patch("builtins.open", autospec=True)
     def test_watch_command_with_create_image_file_should_call_gateway_with_correct_arguments(
         self, mock_open_file, mock_get_accept_file

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,8 +1,6 @@
 import unittest
 from unittest.mock import call, MagicMock, patch
 
-from requests.models import HTTPError
-
 from ntk.gateway import Gateway
 
 
@@ -188,7 +186,8 @@ class TestGateway(unittest.TestCase):
             self.gateway.delete_template(theme_id=6, template_name='asset/custom.css')
 
         expected_logging = [
-            'INFO:root:Deleting asset/custom.css file from theme id #6 failed. -> "name" : This field is required. Please enter filenames.'
+            'INFO:root:Deleting asset/custom.css file from theme id #6 failed. -> "name" : '
+            'This field is required. Please enter filenames.'
         ]
         self.assertEqual(log.output, expected_logging)
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -45,11 +45,14 @@ class TestGateway(unittest.TestCase):
         # check if call request failed
         mock_request.return_value.ok = True
         mock_request.return_value.headers = {'content-type': 'text/html'}
-        with self.assertRaises(HTTPError) as error:
+
+        with self.assertLogs(level='INFO') as log:
             self.gateway.get_themes()
-        self.assertEqual(
-            str(error.exception),
-            'Missing Themes in http://simple.com')
+
+        expected_logging = [
+            'INFO:root:Missing Themes in http://simple.com'
+        ]
+        self.assertEqual(log.output, expected_logging)
 
         # check if call request complated
         mock_request.return_value.headers = {'content-type': 'application/json'}
@@ -65,11 +68,14 @@ class TestGateway(unittest.TestCase):
     def test_create_theme(self, mock_request):
         # check if call request failed
         mock_request.return_value.headers = {'content-type': 'text/html'}
-        with self.assertRaises(HTTPError) as error:
+
+        with self.assertLogs(level='INFO') as log:
             self.gateway.create_theme(name="Test Init Theme")
-        self.assertEqual(
-            str(error.exception),
-            'Theme "Test Init Theme" creation failed.')
+
+        expected_logging = [
+            'INFO:root:Theme "Test Init Theme" creation failed.'
+        ]
+        self.assertEqual(log.output, expected_logging)
 
         # check if call request complated
         mock_request.return_value.ok = True
@@ -91,11 +97,14 @@ class TestGateway(unittest.TestCase):
         # check if call request failed
         mock_request.return_value.ok = True
         mock_request.return_value.headers = {'content-type': 'text/html'}
-        with self.assertRaises(HTTPError) as error:
+
+        with self.assertLogs(level='INFO') as log:
             self.gateway.get_templates(theme_id=6)
-        self.assertEqual(
-            str(error.exception),
-            'Downloading templates files from theme id #6 failed.')
+
+        expected_logging = [
+            'INFO:root:Downloading templates files from theme id #6 failed.'
+        ]
+        self.assertEqual(log.output, expected_logging)
 
         # check if call request complated
         mock_request.return_value.ok = True
@@ -114,12 +123,14 @@ class TestGateway(unittest.TestCase):
     def test_get_template(self, mock_request):
         template_name = 'assets/custom.css'
         # check if call request failed
-        with self.assertRaises(HTTPError) as error:
+        with self.assertLogs(level='INFO') as log:
             mock_request.return_value.ok = False
             self.gateway.get_template(theme_id=6, template_name=template_name)
-        self.assertEqual(
-            str(error.exception),
-            'Downloading assets/custom.css file from theme id #6 failed.')
+
+        expected_logging = [
+            'INFO:root:Downloading assets/custom.css file from theme id #6 failed.'
+        ]
+        self.assertEqual(log.output, expected_logging)
 
         # check if call request complated
         mock_request.return_value.ok = True
@@ -137,12 +148,14 @@ class TestGateway(unittest.TestCase):
     @patch('ntk.gateway.requests.request', autospec=True)
     def test_create_or_update_template(self, mock_request):
         # check if call request failed
-        with self.assertRaises(HTTPError) as error:
+        with self.assertLogs(level='INFO') as log:
             mock_request.return_value.ok = False
             self.gateway.create_or_update_template(theme_id=6, template_name='asset/custom.css')
-        self.assertEqual(
-            str(error.exception),
-            'Uploading asset/custom.css file to theme id #6 failed.')
+
+        expected_logging = [
+            'INFO:root:Uploading asset/custom.css file to theme id #6 failed.'
+        ]
+        self.assertEqual(log.output, expected_logging)
 
         # check if call request complated
         mock_request.return_value.ok = True
@@ -167,16 +180,17 @@ class TestGateway(unittest.TestCase):
     def test_delete_template(self, mock_request):
         mock_request.return_value.headers = {'content-type': 'application/json'}
         # check if call request failed
-        with self.assertRaises(HTTPError) as error:
+        with self.assertLogs(level='INFO') as log:
             mock_request.return_value.ok = False
             mock_request.return_value.json.return_value = {
                 'name': ['This field is required.', 'Please enter filenames.']
             }
             self.gateway.delete_template(theme_id=6, template_name='asset/custom.css')
-        self.assertEqual(
-            str(error.exception),
-            'Deleting asset/custom.css file from theme id #6 failed.'
-            ' -> "name" : This field is required. Please enter filenames.')
+
+        expected_logging = [
+            'INFO:root:Deleting asset/custom.css file from theme id #6 failed. -> "name" : This field is required. Please enter filenames.'
+        ]
+        self.assertEqual(log.output, expected_logging)
 
         # check if call request complated
         mock_request.return_value.ok = True


### PR DESCRIPTION
<h1>Fixed theme kit cannot install and cannot sync on mac os </h1>

<h2>Task</h2>
* [x] Fix installation issues (`__main__`) - see latest commit
* [x] Fix issue with python reading file encoding
* [x] Ignore unaccepted file types
* [x] fix type in `_push_themplate` and `_pull_themplate` function names

<h2>Allowed directories</h2>

* assets/\*
* checkout/\*
* config/
* layout/\*
* partials/\*
* templates/\*
* locales/\*

<h2>Allowed file types</h2>

* .html
* .json
* .png
* .jpg
* .jpeg
* .svg
* .css
* .scss
* .eot
* .tff
* .woff
* .js
* .webp
* .mp4
* .webm
* .mp3
* .pdf